### PR TITLE
Treat empty CUPS (no destinations) as a healthy state, not an error

### DIFF
--- a/scripts/galley_collect.py
+++ b/scripts/galley_collect.py
@@ -129,6 +129,12 @@ def collect(threshold=15, want_completed=False):
             if not tests:
                 raise RuntimeError("ipptool returned no %s result" % label)
             if not gn.test_succeeded(tests[0]):
+                # With no printers configured, cupsd answers CUPS-Get-Printers
+                # with client-error-not-found and "No destinations added." —
+                # a healthy empty state, not a fault. Any other failure
+                # still surfaces as an error.
+                if label == "printers" and gn.no_destinations(tests[0]):
+                    continue
                 raise RuntimeError("ipptool %s request failed: %s"
                                    % (label, tests[0].get("StatusCode", "unknown")))
 

--- a/scripts/galley_normalize.py
+++ b/scripts/galley_normalize.py
@@ -39,6 +39,23 @@ def test_succeeded(test_result):
     return str(test_result.get("StatusCode", "")).startswith("successful")
 
 
+def no_destinations(test_result):
+    """Whether a failed request is cupsd's "no printers configured" reply.
+
+    With zero printers, cupsd answers CUPS-Get-Printers with
+    client-error-not-found and status-message "No destinations added." — a
+    healthy empty state, not a fault. Only that exact reply is benign;
+    any other failure stays an error.
+    """
+    if test_succeeded(test_result):
+        return False
+    if str(test_result.get("StatusCode", "")) != "client-error-not-found":
+        return False
+    attrs = test_result.get("ResponseAttributes") or []
+    message = attrs[0].get("status-message", "") if attrs else ""
+    return "No destinations" in str(message)
+
+
 def response_groups(test_result):
     """Attribute groups of one ipptool test, minus the operation group.
 

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -125,6 +125,74 @@ class SubprocessFailureTest(unittest.TestCase):
         self.assertEqual(snapshot["cupsd"], "error")
         self.assertIsNotNone(snapshot["error"])
 
+    def test_empty_cups_is_a_running_snapshot_with_no_printers(self):
+        # cupsd answers CUPS-Get-Printers with client-error-not-found and
+        # "No destinations added." when no printers are configured. That is
+        # a healthy empty state, not the collector error a failed STATUS
+        # normally is (see test_failed_ipp_status_... above).
+        body = (
+            '#!/bin/sh\n'
+            'case "$5" in\n'
+            '  *get-printers*)\n'
+            '    cat <<\'PLIST\'\n'
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<plist version="1.0">\n'
+            '<dict>\n'
+            '<key>Tests</key>\n'
+            '<array>\n'
+            '<dict>\n'
+            '<key>Name</key><string>Get printers</string>\n'
+            '<key>StatusCode</key><string>client-error-not-found</string>\n'
+            '<key>Successful</key><false />\n'
+            '<key>ResponseAttributes</key>\n'
+            '<array>\n'
+            '<dict>\n'
+            '<key>attributes-charset</key><string>utf-8</string>\n'
+            '<key>status-message</key><string>No destinations added.</string>\n'
+            '</dict>\n'
+            '</array>\n'
+            '</dict>\n'
+            '</array>\n'
+            '</dict>\n'
+            '</plist>\n'
+            'PLIST\n'
+            '    ;;\n'
+            '  *)\n'
+            '    cat <<\'PLIST\'\n'
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<plist version="1.0">\n'
+            '<dict>\n'
+            '<key>Tests</key>\n'
+            '<array>\n'
+            '<dict>\n'
+            '<key>Name</key><string>Get active jobs</string>\n'
+            '<key>StatusCode</key><string>successful-ok</string>\n'
+            '<key>Successful</key><true />\n'
+            '<key>ResponseAttributes</key>\n'
+            '<array>\n'
+            '<dict>\n'
+            '<key>attributes-charset</key><string>utf-8</string>\n'
+            '</dict>\n'
+            '</array>\n'
+            '</dict>\n'
+            '</array>\n'
+            '</dict>\n'
+            '</plist>\n'
+            'PLIST\n'
+            '    ;;\n'
+            'esac\n'
+            'exit 0\n'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            proc, snapshot = self._run_with_path(self._fake_bin(tmp, body))
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(snapshot["cupsd"], "running")
+        self.assertIsNone(snapshot["error"])
+        self.assertEqual(snapshot["printers"], [])
+        self.assertEqual(snapshot["jobs"], [])
+        self.assertEqual(snapshot["summary"]["printers"], 0)
+        self.assertEqual(snapshot["summary"]["activeJobs"], 0)
+
     def test_missing_ipptool_produces_an_error_snapshot(self):
         with tempfile.TemporaryDirectory() as tmp:
             # Only systemctl is faked; ipptool is absent from this dir, and we

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -29,6 +29,49 @@ class ParsePlistTest(unittest.TestCase):
         self.assertEqual(len(data["Tests"]), 1)
 
 
+class NoDestinationsTest(unittest.TestCase):
+    def test_empty_cups_is_a_benign_no_destinations(self):
+        # cupsd returns this exact shape for CUPS-Get-Printers when no
+        # printers are configured -- a healthy empty state, not a fault.
+        result = {
+            "Successful": False,
+            "StatusCode": "client-error-not-found",
+            "ResponseAttributes": [
+                {"attributes-charset": "utf-8",
+                 "attributes-natural-language": "en",
+                 "status-message": "No destinations added."},
+            ],
+        }
+        self.assertTrue(gn.no_destinations(result))
+
+    def test_success_is_never_no_destinations(self):
+        result = {"Successful": True, "StatusCode": "successful-ok"}
+        self.assertFalse(gn.no_destinations(result))
+
+    def test_other_failures_stay_errors(self):
+        result = {
+            "Successful": False,
+            "StatusCode": "server-error-service-unavailable",
+            "ResponseAttributes": [
+                {"attributes-charset": "utf-8",
+                 "status-message": "Service unavailable."},
+            ],
+        }
+        self.assertFalse(gn.no_destinations(result))
+
+    def test_not_found_without_status_message_is_not_benign(self):
+        result = {
+            "Successful": False,
+            "StatusCode": "client-error-not-found",
+            "ResponseAttributes": [{"attributes-charset": "utf-8"}],
+        }
+        self.assertFalse(gn.no_destinations(result))
+
+    def test_missing_response_attributes_is_not_benign(self):
+        result = {"Successful": False, "StatusCode": "client-error-not-found"}
+        self.assertFalse(gn.no_destinations(result))
+
+
 class AsListTest(unittest.TestCase):
     def test_wraps_scalar(self):
         # Single-valued IPP attributes arrive as scalars, not one-element lists.


### PR DESCRIPTION
## What

When CUPS is running but has **no printers configured**, cupsd answers `CUPS-Get-Printers` with `client-error-not-found` and status-message `"No destinations added."` — a healthy empty state, not a fault. The collector currently raises on any non-success status, so the widget shows `RuntimeError: ipptool printers request failed: client-error-not-found` forever, and the panel's intended calm "No printers configured" empty state (`Panel.qml`) is never reached.

This special-cases exactly that reply: it is treated as an empty printer list, producing a normal `cupsd: "running"` snapshot with zero printers, zero jobs, and no error. Any other failure (e.g. `server-error-service-unavailable`) still surfaces as a collector error, preserving the existing STATUS-assertion guard.

## Changes

- `scripts/galley_normalize.py`: new pure `no_destinations(test)` helper — true only for `client-error-not-found` **with** the `"No destinations"` status-message.
- `scripts/galley_collect.py`: skip the raise for the printers request when `no_destinations()` matches; `response_groups()` already yields `[]` for that response.
- `tests/test_normalize.py`: 5 unit tests for `no_destinations` (benign reply, success, other failures, missing status-message, missing response attributes).
- `tests/test_collect.py`: integration test driving a fake `ipptool` through the real empty-CUPS response shape, asserting a `running` snapshot with no error.

## Verification

- `./bin/test` green: 96 Python tests + 45 node tests.
- Live check on a machine with zero configured printers: `python3 scripts/galley_collect.py` now emits `{"cupsd": "running", ..., "printers": [], "jobs": [], "error": null}`.

No changes needed in `Model.js`/`Panel.qml`/`manifest.json` — the "No printers configured" empty state already existed.